### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/alex----held/1f2ebed6-22af-4c25-93d3-fb706aa677ca/2988ffdd-29c2-4467-8dc7-7d9e5282e656/_apis/work/boardbadge/368471de-1e1a-4156-a50b-83b04b735f1c)](https://dev.azure.com/alex----held/1f2ebed6-22af-4c25-93d3-fb706aa677ca/_boards/board/t/2988ffdd-29c2-4467-8dc7-7d9e5282e656/Microsoft.RequirementCategory)
 [![Board Status](https://dev.azure.com/alexander-held/00124096-a538-40ea-bac4-02a51826d901/8a0ca3cb-69d4-48e2-b635-d4aa53497c59/_apis/work/boardbadge/0f6795f5-d696-4477-b69e-273f081deda4)](https://dev.azure.com/alexander-held/00124096-a538-40ea-bac4-02a51826d901/_boards/board/t/8a0ca3cb-69d4-48e2-b635-d4aa53497c59/Microsoft.RequirementCategory)
 # HardCode.MockServer
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/alex----held/1f2ebed6-22af-4c25-93d3-fb706aa677ca/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.