### PR TITLE
chore(deps): bump from  3.1.0-preview3 to 3.1.0 lts 

### DIFF
--- a/src/NinjaTools.FluentMockServer.API/NinjaTools.FluentMockServer.API.csproj
+++ b/src/NinjaTools.FluentMockServer.API/NinjaTools.FluentMockServer.API.csproj
@@ -9,12 +9,12 @@
       <PackageReference Include="AutoMapper" Version="9.0.0" />
       <PackageReference Include="AutoMapper.Collection.EntityFrameworkCore" Version="1.0.1" />
       <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
-      <PackageReference Include="Bogus" Version="28.4.2" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0-preview3.19555.2" />
+      <PackageReference Include="Bogus" Version="28.4.4" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0-preview3.19554.8" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.0-preview3.19554.8" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0-preview3.19554.8" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.0-preview3.19554.8" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.0" />
       <PackageReference Include="Serilog" Version="2.9.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
       <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />

--- a/test/NinjaTools.FluentMockServer.Tests/NinjaTools.FluentMockServer.Tests.csproj
+++ b/test/NinjaTools.FluentMockServer.Tests/NinjaTools.FluentMockServer.Tests.csproj
@@ -9,9 +9,9 @@
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.11.0" />
         <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
-        <PackageReference Include="Bogus" Version="28.4.1" />
+        <PackageReference Include="Bogus" Version="28.4.4" />
         <PackageReference Include="DeepCloner" Version="0.10.2" />
-        <PackageReference Include="Divergic.Logging.Xunit" Version="3.1.0" />
+        <PackageReference Include="Divergic.Logging.Xunit" Version="3.2.1" />
         <PackageReference Include="FluentAssertions" Version="5.9.0" />
         <PackageReference Include="FluentAssertions.Json" Version="5.3.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />


### PR DESCRIPTION
* chore(deps): bump Microsoft.AspNetCore.Mvc.NewtonsoftJson

Bumps [Microsoft.AspNetCore.Mvc.NewtonsoftJson](https://github.com/aspnet/AspNetCore) from 3.1.0-preview3.19555.2 to 3.1.0.
- [Release notes](https://github.com/aspnet/AspNetCore/releases)
- [Changelog](https://github.com/aspnet/AspNetCore/blob/master/docs/CrossRepoBreakingChanges.md)
- [Commits](https://github.com/aspnet/AspNetCore/compare/v3.1.0-preview3.19555.2...v3.1.0)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

* chore(deps): bump Divergic.Logging.Xunit from 3.1.0 to 3.2.1

Bumps [Divergic.Logging.Xunit](https://github.com/Divergic/Divergic.Logging.Xunit) from 3.1.0 to 3.2.1.
- [Release notes](https://github.com/Divergic/Divergic.Logging.Xunit/releases)
- [Commits](https://github.com/Divergic/Divergic.Logging.Xunit/compare/v3.1.0...3.2.1)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

* chore(deps): bump Microsoft.EntityFrameworkCore.Tools

Bumps [Microsoft.EntityFrameworkCore.Tools](https://github.com/aspnet/EntityFrameworkCore) from 3.1.0-preview3.19554.8 to 3.1.0.
- [Release notes](https://github.com/aspnet/EntityFrameworkCore/releases)
- [Commits](https://github.com/aspnet/EntityFrameworkCore/compare/v3.1.0-preview3.19554.8...v3.1.0)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

* chore(deps): bump Bogus from 28.4.1 to 28.4.4

Bumps [Bogus](https://github.com/bchavez/Bogus) from 28.4.1 to 28.4.4.
- [Release notes](https://github.com/bchavez/Bogus/releases)
- [Changelog](https://github.com/bchavez/Bogus/blob/master/HISTORY.md)
- [Commits](https://github.com/bchavez/Bogus/compare/v28.4.1...v28.4.4)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

* chore(deps): bump Microsoft.EntityFrameworkCore

Bumps [Microsoft.EntityFrameworkCore](https://github.com/aspnet/EntityFrameworkCore) from 3.1.0-preview3.19554.8 to 3.1.0.
- [Release notes](https://github.com/aspnet/EntityFrameworkCore/releases)
- [Commits](https://github.com/aspnet/EntityFrameworkCore/compare/v3.1.0-preview3.19554.8...v3.1.0)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

* chore(deps): bump Microsoft.EntityFrameworkCore.Design from 3.1.0… (#18)

Bumps [Microsoft.EntityFrameworkCore.Design](https://github.com/aspnet/EntityFrameworkCore) from 3.1.0-preview3.19554.8 to 3.1.0.
- [Release notes](https://github.com/aspnet/EntityFrameworkCore/releases)
- [Commits](https://github.com/aspnet/EntityFrameworkCore/compare/v3.1.0-preview3.19554.8...v3.1.0)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Co-authored-by: Alexander Held <git@alexanderheld.net>

* chore(deps): bump Microsoft.EntityFrameworkCore.SqlServer from 3.… (#16)

Bumps [Microsoft.EntityFrameworkCore.SqlServer](https://github.com/aspnet/EntityFrameworkCore) from 3.1.0-preview3.19554.8 to 3.1.0.
- [Release notes](https://github.com/aspnet/EntityFrameworkCore/releases)
- [Commits](https://github.com/aspnet/EntityFrameworkCore/compare/v3.1.0-preview3.19554.8...v3.1.0)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Co-authored-by: Alexander Held <git@alexanderheld.net>

Co-authored-by: dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>