### PR TITLE
Fix version conflicts caused by PR#491

### DIFF
--- a/src/NinjaTools.FluentMockServer.API/NinjaTools.FluentMockServer.API.csproj
+++ b/src/NinjaTools.FluentMockServer.API/NinjaTools.FluentMockServer.API.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <LangVersion>Preview</LangVersion>
         <AssemblyVersion>1.0.0</AssemblyVersion>
@@ -22,12 +22,12 @@
       <PackageReference Include="Ardalis.GuardClauses" Version="1.3.3" />
       <PackageReference Include="AutoMapper" Version="9.0.0" />
       <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.8" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0-beta1-final" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.1" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.1" />
       <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.1" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.8" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0" />

--- a/src/NinjaTools.FluentMockServer/NinjaTools.FluentMockServer.csproj
+++ b/src/NinjaTools.FluentMockServer/NinjaTools.FluentMockServer.csproj
@@ -5,7 +5,7 @@
         <ProjectGuid>36A37D14-D7FC-4E32-8F48-5FB606818757</ProjectGuid>
         <AssemblyVersion>1.1.1</AssemblyVersion>
         <LangVersion>8.0</LangVersion>
-        <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
+        <TargetFrameworks>net5.0;</TargetFrameworks>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
@@ -40,7 +40,7 @@
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <DebugSymbols>true</DebugSymbols>
-        <TargetFrameworks>netstandard2.1;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
         <DocumentationFile>bin\Release\HardCoded.MockServer.xml</DocumentationFile>
         <NoWarn>CS1591;</NoWarn>
     </PropertyGroup>

--- a/test/NinjaTools.FluentMockServer.API.Tests/NinjaTools.FluentMockServer.API.Tests.csproj
+++ b/test/NinjaTools.FluentMockServer.API.Tests/NinjaTools.FluentMockServer.API.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>

--- a/test/NinjaTools.FluentMockServer.Tests/NinjaTools.FluentMockServer.Tests.csproj
+++ b/test/NinjaTools.FluentMockServer.Tests/NinjaTools.FluentMockServer.Tests.csproj
@@ -2,12 +2,12 @@
 
     <PropertyGroup>
         <ProjectGuid>B687AFC5-D484-4240-B89C-ACEAEA7B8A96</ProjectGuid>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <LangVersion>Preview</LangVersion>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
         <Nullable>Enable</Nullable>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
     
     <ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bchore(deps): (deps): bump Microsoft.AspNetCore.Mvc.NewtonsoftJson from 3.1.9 to 5.0.8. [(PR#491)](https://github.com/alex-held/NinjaTools.FluentMockServer/pull/491).
Hope this fix can help you.

Best regards,
sucrose